### PR TITLE
Add support for Sublime Text / iTerm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ This reporter is tested and actively used in WebStorm with [eslint-grunt](https:
 $FILE_PATH$[ \t]*[:;,\[\(\{<]$LINE$(?:[:;,\.]$COLUMN$)?.*
 ````
 
+### Sublime Text
+
+CMD+click on files in [iTerm](https://www.iterm2.com/) should open files at the correct line when iTerm's Semantic History is set up to open files in Sublime Text.
+
+See configuration instructions below.
+
 ## Usage
 
 Install from NPM
@@ -80,6 +86,18 @@ require('eslint-path-formatter').color(false);
 ````js
 require('eslint-path-formatter').options.sourcemap = false;
 ````
+
+### Output line numbers for Sublime Text
+
+```js
+require('eslint-path-formatter').editor('sublime');
+```
+
+This way, the reporter will output messages in this format:
+
+```
+path/to/file.js:line:char
+```
 
 ## Example output
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+:warning: DEPRECATED
+
+This project isn't maintained anymore.
+
+Please use this friendly formatter instead: https://github.com/royriojas/eslint-friendly-formatter
+
 # eslint-path-formatter
 
 [![Build Status](https://secure.travis-ci.org/Bartvds/eslint-path-formatter.png?branch=master)](http://travis-ci.org/Bartvds/eslint-path-formatter) [![Dependency Status](https://gemnasium.com/Bartvds/eslint-path-formatter.png)](https://gemnasium.com/Bartvds/eslint-path-formatter) [![NPM version](https://badge.fury.io/js/eslint-path-formatter.png)](http://badge.fury.io/js/eslint-path-formatter)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-:warning: DEPRECATED
+#### :warning: DEPRECATED
 
 This project isn't maintained anymore.
 

--- a/index.js
+++ b/index.js
@@ -226,6 +226,6 @@ module.exports.options = options;
 module.exports.color = function (enable) {
 	options.style = enable ? 'ansi' : false;
 };
-module.exports.editor: function(editor) {
+module.exports.editor = function(editor) {
 	options.editor = (editor == 'sublime') ? 'sublime' : 'webstorm';
 };

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 
-var options = {style: 'ansi', sourcemap:true};
+var options = {style: 'ansi', sourcemap: true, editor: 'webstorm'};
 // copied colors from color.js
 var colorWrap = {
 	//grayscale
@@ -186,7 +186,12 @@ module.exports = function (results) {
 					str += path.resolve(position.source);
 				}
 				if (typeof position.column !== 'undefined') {
-					str += '(' + position.line + ',' + position.column + '):';
+					if (options.editor === 'webstorm') {
+						str += '(' + position.line + ',' + position.column + '):';
+					}
+					if (options.editor === 'sublime') {
+						str += ':' + position.line + ':' + position.column;
+					}
 				}
 				if (typeof message.ruleId !== 'undefined') {
 					str += '\n' + warn('[' +  message.ruleId + '] ');
@@ -220,4 +225,7 @@ module.exports = function (results) {
 module.exports.options = options;
 module.exports.color = function (enable) {
 	options.style = enable ? 'ansi' : false;
+};
+module.exports.editor: function(editor) {
+	options.editor = (editor == 'sublime') ? 'sublime' : 'webstorm';
 };

--- a/index.js
+++ b/index.js
@@ -227,5 +227,5 @@ module.exports.color = function (enable) {
 	options.style = enable ? 'ansi' : false;
 };
 module.exports.editor = function(editor) {
-	options.editor = (editor == 'sublime') ? 'sublime' : 'webstorm';
+	options.editor = (editor === 'sublime') ? 'sublime' : 'webstorm';
 };


### PR DESCRIPTION
iTerm can open files in Sublime Text at the correct line when it detects certain patterns.

This PR adds an option to make the module compatible with Sublime / iTerm.

Apologies for the lack of tests, I wasn't sure how to do that.
