### PR TITLE
improve paths: replace (112,28): with :112:28

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ module.exports = function (results) {
 
 				str += fail(getMessageType(message).toLocaleUpperCase()) + ' at ';
 				if (position.source.slice(0, dataUrlPrefix.length).toLowerCase() === dataUrlPrefix) {
-					str += position.source;
+					str += path.relative('../../../../', position.source.split(',')[1]);
 				}
 				else {
 					str += path.resolve(position.source);

--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ module.exports = function (results) {
 					str += path.resolve(position.source);
 				}
 				if (typeof position.column !== 'undefined') {
-					str += '(' + position.line + ',' + position.column + '):';
+					str += ':' + position.line + ':' + position.column;
 				}
 				if (typeof message.ruleId !== 'undefined') {
 					str += '\n' + warn('[' +  message.ruleId + '] ');


### PR DESCRIPTION
1. apply default path convention

default path convention is well-known in vim with plugin, sublime, vs-code, webstorm and any another code-editors and ide

2. remove path trash

turns:
`ERROR at data:application/json;base64,../../../../components/action/Docheck/intent/Default.cjsx:112:28`
into:
`ERROR at components/action/Docheck/intent/Default.cjsx:112:28`